### PR TITLE
fix async footer bug

### DIFF
--- a/src/app/footer.tsx
+++ b/src/app/footer.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { User } from "lucide-react";
 import { API } from "@/utils/constant";
 import Link from "next/link";
+import useSWR from "swr";
 const navigation = [
   { name: "Donate", href: "/getinvolved" },
   { name: "Volunteer", href: "/getinvolved" },
@@ -14,9 +15,28 @@ function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(" ");
 }
 
-export default async function Footer() {
+const fetcher = async (url: string) => {
+  const response = await fetch(url, { cache: "no-store" });
+  const data = await response.json();
+  if (!data.data) {
+    return [];
+  }
+  const footer_email = data.data.attributes.footer_email;
+  const footer_phone_number = data.data.attributes.footer_phone_number;
+  return [footer_email, footer_phone_number];
+};
+
+// TODO: Consider migrating to a server-side rendered component
+export default function Footer() {
   const pathname = usePathname();
-  const footer_email_phone: string[] = await fetchFooter();
+  const { data: footerData, error } = useSWR(
+    `${API}/home-page?populate=footer_email`,
+    fetcher
+  );
+
+  if (error) {
+    console.error("Error fetching footer data:", error);
+  }
 
   return (
     <div className="w-full content-between px-5 text-white bg-[#860e13]">
@@ -28,11 +48,17 @@ export default async function Footer() {
         <div className="m-4 flex flex-col sm:items-center">
           <div className="text-xl underline">Contact Us</div>
           <p className="text-md font-medium sm:pt-1">
-            <a href={`mailto:${footer_email_phone[0]}`}>
-              {footer_email_phone[0]}
-            </a>
+            {footerData ? (
+              <a href={`mailto:${footerData[0]}`}>{footerData[0]}</a>
+            ) : (
+              <a>Loading...</a>
+            )}
           </p>
-          <p className="text-md font-medium sm:pt-1">{footer_email_phone[1]}</p>
+          {footerData ? (
+            <p className="text-md font-medium sm:pt-1">{footerData[1]}</p>
+          ) : (
+            <a>Loading...</a>
+          )}
         </div>
 
         <div className="m-4 flex flex-col sm:items-center">
@@ -99,21 +125,4 @@ export default async function Footer() {
       </div>
     </div>
   );
-}
-
-async function fetchFooter() {
-  const email_phone: string[] = [];
-  const response = await fetch(`${API}/home-page?populate=footer_email`, {
-    cache: "no-store",
-  });
-  const data = await response.json();
-  if (!data.data) {
-    return [];
-  }
-  const footer_email = data.data.attributes.footer_email;
-  const footer_phone_number = data.data.attributes.footer_phone_number;
-  email_phone.push(footer_email);
-  email_phone.push(footer_phone_number);
-
-  return email_phone;
 }


### PR DESCRIPTION
This change is meant to fix the following error message that comes from defining Footer as an async component when it is a client component (only should be done if it is a server-side component). We should consider the switch to making Footer a server-side component which gets rid of the use of spinners, but this would require a workaround with usePathname (is using this even necessary? may need to look more into it).
<img width="1233" alt="image" src="https://github.com/Hack4Impact-UMD/the-giving-heart/assets/46267426/d5571e86-3640-4a1a-8bcd-4742603835ea">

Likely to be causing the following bug (hard to reproduce but comes up randomly where network requests to populate the footer are spammed)
<img width="1506" alt="image" src="https://github.com/Hack4Impact-UMD/the-giving-heart/assets/46267426/6e63379b-4d6a-40cd-bb9a-3510a9f7a2df">
