### PR TITLE
fix register button bug + disable if user is not logged in

### DIFF
--- a/src/app/dashboard/eventCard.tsx
+++ b/src/app/dashboard/eventCard.tsx
@@ -16,6 +16,7 @@ import globe from ".././_images/globe.svg";
 import AlertMessage from "../../components/ui/AlertMessage";
 import { useAuthContext } from "@/utils/context/AuthContext";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 interface EventCardProps {
   key: string;
@@ -31,8 +32,16 @@ export const EventCard: React.FC<EventCardProps> = ({
   image,
   setShowErrorMessage,
 }) => {
+  const router = useRouter();
   const eventObject = JSON.parse(event);
   const volunteerRolesObject = JSON.parse(volunteerRoles);
+  const { user, setUser } = useAuthContext();
+
+  const handleButtonClick = () => {
+    router.push(
+      `/event-signup?event=${event}&volunteerRoles=${volunteerRoles}`
+    );
+  };
 
   return (
     <div className="drop-shadow-[0_10px_10px_rgba(0,0,0,0.50)]">
@@ -94,24 +103,14 @@ export const EventCard: React.FC<EventCardProps> = ({
         </CardContent>
 
         <CardFooter className="flex justify-center items-center">
-          {/**TODO: Set to inactive if user does not exist and have a banner at top saying you need to be signed in! */}
-
           <Button
             variant="default"
             size="default"
             className="bg-[#ED1C24] text-white rounded-md"
+            onClick={handleButtonClick}
+            disabled={!user}
           >
-            <Link
-              href={{
-                pathname: `/event-signup`,
-                query: {
-                  event: event,
-                  volunteerRoles: volunteerRoles,
-                },
-              }}
-            >
-              Register
-            </Link>
+            Register
           </Button>
         </CardFooter>
       </Card>


### PR DESCRIPTION
Previously, there was a bug that required the user to click the "Register" button multiple times for them to be redirected to event-signup (it should only require a single click). This PR fixes that issue.

Additionally, we disable the register button if the user is not logged in:
<img width="247" alt="image" src="https://github.com/Hack4Impact-UMD/the-giving-heart/assets/46267426/c8eb6db2-88f7-4ad9-bdf5-e074325cdf53">
